### PR TITLE
feat: 유저 도메인 구현

### DIFF
--- a/pome-server/src/main/java/server/pome/global/domain/User.java
+++ b/pome-server/src/main/java/server/pome/global/domain/User.java
@@ -1,0 +1,60 @@
+package server.pome.global.domain;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "users")
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(nullable = false, unique = true)
+  private Long id;
+
+  @ElementCollection
+  @CollectionTable(name = "user_from_ids", joinColumns = @JoinColumn(name = "user_id"))
+  @Column(name = "from_id")
+  @Comment("신청자 아이디 목록")
+  private List<Integer> fromIds;
+
+  @Column(name = "user_name", nullable = false, unique = true)
+  @Comment("유저 닉네임")
+  private String userName;
+
+  @Column(name = "password", nullable = false)
+  @Comment("비밀번호")
+  private String password;
+
+  @Column(name = "matching", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 1")
+  @Comment("매칭 활성화 여부 / 기본값 = True")
+  private Boolean matching;
+
+  @Column(name = "introduction", nullable = true, columnDefinition = "LONGTEXT")
+  @Comment("자기소개")
+  private String introduction;
+
+  @Column(name = "job", nullable = true, length = 20)
+  @Comment("희망 직무")
+  private String job;
+
+  @Column(name = "profile_image", length = 2048)
+  @Comment("프로필 사진")
+  private String profileImage;
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #6

## 🚀 작업 사항
- ERD 설계에 따라 User 엔티티 필드 정의
- 신청자 ID 목록(`fromIds`)을 `@ElementCollection`으로 매핑  
  → `user_from_ids`라는 별도 테이블에 `user_id`와 `from_id` 저장

### 🔎 설계 이유 및 비교
- JPA에서 `List<Integer>`는 단일 컬럼에 매핑할 수 없어 별도 테이블 필요
- `@OneToMany` vs `@ElementCollection` 비교:
  - `@OneToMany`: 신청자 자체를 엔티티로 관리, 고유 ID(PK) 필요
  - `@ElementCollection`: 신청자의 ID 값만 저장, 별도 엔티티 아님
-> 신청자의 추가적인 속성없이 ID만 저장하면 되기 때문에 의존관계와 복잡도를 고려하여 값만 저장하는 ElementCollection으로 구현함

## 📸 스크린샷
- users
<img width="557" height="125" alt="image" src="https://github.com/user-attachments/assets/70fcfe76-dfbc-4784-ae54-932dd7051a34" />

- user_from_ids
<img width="550" height="52" alt="image" src="https://github.com/user-attachments/assets/5aa60985-d4f3-4b60-a52e-7e22035dfdc4" />

## 📢 참고사항
- `fromIds`는 값 컬렉션이므로 추후 신청자 정보를 확장할 필요가 생기면 `@OneToMany`로 전환 가능
