### PR TITLE
refactor: 공통 응답 및 에러 처리 구조 리팩토링

### DIFF
--- a/pome-server/src/main/java/server/pome/global/domain/BaseResponse.java
+++ b/pome-server/src/main/java/server/pome/global/domain/BaseResponse.java
@@ -1,60 +1,63 @@
 package server.pome.global.domain;
 
-import static server.pome.global.exception.BaseResponseStatus.SUCCESS;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import server.pome.global.exception.BaseResponseStatus;
 
 @Getter
-@AllArgsConstructor
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
 public class BaseResponse<T> {
 
   @Schema(title = "성공 여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-  private final Boolean isSuccess;
+  private final boolean isSuccess;
 
-  @Schema(title = "식별 코드", example = "1000", requiredMode = RequiredMode.REQUIRED)
+  @Schema(title = "응답 코드", example = "1000", requiredMode = RequiredMode.REQUIRED)
   private final int code;
 
-  @Schema(title = "메시지", example = "요청에 성공했습니다.", requiredMode = RequiredMode.REQUIRED)
+  @Schema(title = "응답 메시지", example = "요청에 성공했습니다.", requiredMode = RequiredMode.REQUIRED)
   private final String message;
 
   @Schema(title = "응답 데이터", description = "요청 결과 데이터", nullable = true)
-  @JsonInclude(Include.NON_NULL)
-  private T result;
-
-  // 요청 성공 응답
-  public static <T> BaseResponse<T> success(T result) {
-    return new BaseResponse<>(SUCCESS, result);
-  }
-
-  // 요청 실패 응답
-  public static BaseResponse<?> error(BaseResponseStatus status) {
-    return new BaseResponse<>(status, null);
-  }
-
-  // 커스텀 메시지 실패 응답
-  public static BaseResponse<?> error(BaseResponseStatus status, String customMessage) {
-    return new BaseResponse<>(status.isSuccess(), status.getCode(), customMessage, null);
-  }
-
-  private BaseResponse(BaseResponseStatus status, T result) {
-    this.isSuccess = status.isSuccess();
-    this.code = status.getCode();
-    this.message = status.getMessage();
-    this.result = result;
-  }
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final T result;
 
   private BaseResponse(boolean isSuccess, int code, String message, T result) {
     this.isSuccess = isSuccess;
     this.code = code;
     this.message = message;
     this.result = result;
+  }
+
+  // 요청 성공
+  public static <T> BaseResponse<T> success(T result) {
+    return new BaseResponse<>(
+        BaseResponseStatus.SUCCESS.isSuccess(),
+        BaseResponseStatus.SUCCESS.getCode(),
+        BaseResponseStatus.SUCCESS.getMessage(),
+        result
+    );
+  }
+
+  // 요청 실패
+  public static BaseResponse<?> error(BaseResponseStatus status) {
+    return new BaseResponse<>(
+        status.isSuccess(),
+        status.getCode(),
+        status.getMessage(),
+        null
+    );
+  }
+
+  // 요청 실패(커스텀 메시지 사용)
+  public static BaseResponse<?> error(BaseResponseStatus status, String customMessage) {
+    return new BaseResponse<>(
+        status.isSuccess(),
+        status.getCode(),
+        customMessage,
+        null
+    );
   }
 }

--- a/pome-server/src/main/java/server/pome/global/exception/BaseException.java
+++ b/pome-server/src/main/java/server/pome/global/exception/BaseException.java
@@ -6,18 +6,14 @@ import lombok.Getter;
 public class BaseException extends RuntimeException {
 
   private final BaseResponseStatus status;
-  private final String customMessage;
 
   public BaseException(BaseResponseStatus status) {
     super(status.getMessage());
     this.status = status;
-    this.customMessage = null;
   }
 
   public BaseException(BaseResponseStatus status, String customMessage) {
     super(customMessage);
     this.status = status;
-    this.customMessage = customMessage;
   }
-
 }

--- a/pome-server/src/main/java/server/pome/global/exception/BaseResponseStatus.java
+++ b/pome-server/src/main/java/server/pome/global/exception/BaseResponseStatus.java
@@ -17,7 +17,7 @@ public enum BaseResponseStatus {
   // 3000번대: 응답 오류
   RESPONSE_ERROR(false, HttpStatus.BAD_REQUEST, 3000, "값을 불러오는데 실패하였습니다."),
 
-  // 4000번대: DB/서버 오류
+  // 4000번대: 서버/DB 오류
   DATABASE_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR, 4000, "데이터베이스 연결에 실패하였습니다."),
   SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR, 4001, "서버와의 연결에 실패하였습니다.");
 

--- a/pome-server/src/main/java/server/pome/global/exception/GlobalExceptionHandler.java
+++ b/pome-server/src/main/java/server/pome/global/exception/GlobalExceptionHandler.java
@@ -1,56 +1,44 @@
 package server.pome.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import server.pome.global.domain.BaseResponse;
 
-import static org.springframework.http.HttpStatus.*;
-import static server.pome.global.exception.BaseResponseStatus.*;
-
+@RestControllerAdvice
 @Slf4j
-@ControllerAdvice
 public class GlobalExceptionHandler {
 
-  // 커스텀 BaseException 처리
+  // 커스텀 예외 처리
   @ExceptionHandler(BaseException.class)
-  public ResponseEntity<BaseResponse<?>> handlerHttpMessageException(BaseException e) {
-    BaseResponseStatus status = e.getStatus();
-    String message = e.getCustomMessage() != null ? e.getCustomMessage() : e.getMessage();
-
-    log.warn("[BaseException] code = {}, message = {}", status.getCode(), message);
-
+  public ResponseEntity<BaseResponse<?>> handleBaseException(BaseException e) {
+    log.warn("[BaseException] code={}, message={}", e.getStatus().getCode(), e.getMessage());
     return ResponseEntity
-        .status(status.getHttpStatus())
-        .body(BaseResponse.error(status, message));
+        .status(e.getStatus().getHttpStatus())
+        .body(BaseResponse.error(e.getStatus(), e.getMessage()));
   }
 
-  // Valid 예외 처리
+  // 유효성 검증 실패 처리
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<BaseResponse<?>> handleValidationException(
-      MethodArgumentNotValidException e) {
-    String errorMessage = e.getBindingResult().getFieldErrors().stream()
+  public ResponseEntity<BaseResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+    String message = e.getBindingResult().getFieldErrors().stream()
         .map(err -> err.getField() + ": " + err.getDefaultMessage())
         .findFirst()
         .orElse("입력값이 올바르지 않습니다.");
-
-    log.warn("[ValidationException] {}", errorMessage);
-
     return ResponseEntity
-        .badRequest()
-        .body(BaseResponse.error(REQUEST_ERROR, errorMessage));
+        .status(HttpStatus.BAD_REQUEST)
+        .body(BaseResponse.error(BaseResponseStatus.REQUEST_ERROR, message));
   }
 
-  // 처리되지 않은 예외 처리
+  // 처리되지 않음 모든 예외에 대한 기본 처리
   @ExceptionHandler(Exception.class)
   public ResponseEntity<BaseResponse<?>> handleUnhandledException(Exception e) {
-    log.error("[UnhandledException] {}", e.getMessage(), e);
-
+    log.error("[UnhandledException] ", e);
     return ResponseEntity
-        .status(SERVER_ERROR.getHttpStatus())
-        .body(BaseResponse.error(SERVER_ERROR));
+        .status(BaseResponseStatus.SERVER_ERROR.getHttpStatus())
+        .body(BaseResponse.error(BaseResponseStatus.SERVER_ERROR));
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #14 

## 🚀 작업 사항
- BaseResponse 
    - 생성자 제거 후 success, error() 정적 팩토리 메서드로 통일
    - null인 result는 JSON응답에서 제외되도록 처리
- BaseException
    - customMessage 필드 제거 -> getMessage()로 일원화
- GlobalExceptionHandler 
    - 반복적인 try-catch 제거 -> 통일된 BaseResponse 포맷 반환

