### PR TITLE
[Feat] 회원가입, 회원 조회 및 수정 API 구현

### DIFF
--- a/pome-server/src/main/java/server/pome/Portfolio/repository/PortfolioRepository.java
+++ b/pome-server/src/main/java/server/pome/Portfolio/repository/PortfolioRepository.java
@@ -1,0 +1,12 @@
+package server.pome.Portfolio.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import server.pome.global.domain.Portfolio;
+
+@Repository
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+
+  Portfolio findByUser_Id(Long userId);
+}

--- a/pome-server/src/main/java/server/pome/global/domain/User.java
+++ b/pome-server/src/main/java/server/pome/global/domain/User.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.Comment;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "users")
-public class User {
+public class User extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/pome-server/src/main/java/server/pome/global/domain/User.java
+++ b/pome-server/src/main/java/server/pome/global/domain/User.java
@@ -28,19 +28,27 @@ public class User extends BaseEntity {
   @Column(nullable = false, unique = true)
   private Long id;
 
+  @Column(name = "password", nullable = false)
+  @Comment("비밀번호")
+  private String password;
+
   @ElementCollection
   @CollectionTable(name = "user_from_ids", joinColumns = @JoinColumn(name = "user_id"))
   @Column(name = "from_id")
   @Comment("신청자 아이디 목록")
   private List<Integer> fromIds;
 
-  @Column(name = "user_name", nullable = false, unique = true)
-  @Comment("유저 닉네임")
+  @Column(name = "user_name", nullable = false)
+  @Comment("유저 이름")
   private String userName;
 
-  @Column(name = "password", nullable = false)
-  @Comment("비밀번호")
-  private String password;
+  @Column(name = "nick_name", nullable = false, unique = true)
+  @Comment("유저 닉네임")
+  private String nickName;
+
+  @Column(name = "like_count", nullable = false)
+  @Comment("좋아요 수")
+  private int likeCount = 0;
 
   @Column(name = "matching", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 1")
   @Comment("매칭 활성화 여부 / 기본값 = True")
@@ -57,4 +65,14 @@ public class User extends BaseEntity {
   @Column(name = "profile_image", length = 2048)
   @Comment("프로필 사진")
   private String profileImage;
+
+  // 회원 정보 업데이트
+  public void updateUserInfo(String name, String nickname, boolean matching, String introduction,
+      String job) {
+    this.userName = name;
+    this.nickName = nickname;
+    this.matching = matching;
+    this.introduction = introduction;
+    this.job = job;
+  }
 }

--- a/pome-server/src/main/java/server/pome/global/exception/BaseResponseStatus.java
+++ b/pome-server/src/main/java/server/pome/global/exception/BaseResponseStatus.java
@@ -14,13 +14,16 @@ public enum BaseResponseStatus {
   INVALID_USER(false, HttpStatus.UNAUTHORIZED, 2001, "유효하지 않은 사용자입니다."),
   INVALID_TOKEN(false, HttpStatus.UNAUTHORIZED, 2002, "유효하지 않은 토큰입니다."),
 
+  // users
+  USER_NOT_FOUND(false, HttpStatus.NOT_FOUND, 2003, "존재하지 않는 사용자입니다."),
+  DUPLICATE_USER(false, HttpStatus.BAD_REQUEST, 2004, "중복된 닉네임입니다."),
+
   // 3000번대: 응답 오류
   RESPONSE_ERROR(false, HttpStatus.BAD_REQUEST, 3000, "값을 불러오는데 실패하였습니다."),
 
   // 4000번대: DB/서버 오류
   DATABASE_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR, 4000, "데이터베이스 연결에 실패하였습니다."),
   SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR, 4001, "서버와의 연결에 실패하였습니다.");
-
   private final boolean isSuccess;
   private final HttpStatus httpStatus;
   private final int code;

--- a/pome-server/src/main/java/server/pome/user/controller/UserController.java
+++ b/pome-server/src/main/java/server/pome/user/controller/UserController.java
@@ -1,0 +1,44 @@
+package server.pome.user.controller;
+
+import com.mysql.cj.x.protobuf.Mysqlx.Ok;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.pome.global.domain.BaseResponse;
+import server.pome.global.exception.BaseException;
+import server.pome.global.exception.BaseResponseStatus;
+import server.pome.user.dto.request.UserLoginRequest;
+import server.pome.user.dto.response.UserLoginResponse;
+import server.pome.user.service.UserService;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+@Tag(name = "User", description = "회원 API")
+public class UserController {
+  private final UserService userService;
+
+  // 로그인
+  @Operation(summary = "로그인")
+  @PostMapping("/login")
+  public ResponseEntity<BaseResponse<UserLoginResponse>> login(
+      @Valid @RequestBody UserLoginRequest userLoginRequest
+  ) {
+    UserLoginResponse result = userService.login(userLoginRequest);
+    return ResponseEntity.ok(BaseResponse.success(result));
+  }
+
+  // 회원 정보 조회
+
+  // 회원 정보 수정
+
+}

--- a/pome-server/src/main/java/server/pome/user/controller/UserController.java
+++ b/pome-server/src/main/java/server/pome/user/controller/UserController.java
@@ -1,22 +1,25 @@
 package server.pome.user.controller;
 
-import com.mysql.cj.x.protobuf.Mysqlx.Ok;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import server.pome.global.domain.BaseResponse;
-import server.pome.global.exception.BaseException;
-import server.pome.global.exception.BaseResponseStatus;
+import server.pome.user.dto.request.CreateUserRequest;
+import server.pome.user.dto.request.UpdateUserRequest;
 import server.pome.user.dto.request.UserLoginRequest;
+import server.pome.user.dto.response.CreateUserResponse;
+import server.pome.user.dto.response.GetUserResponse;
+import server.pome.user.dto.response.UpdateUserResponse;
 import server.pome.user.dto.response.UserLoginResponse;
 import server.pome.user.service.UserService;
 
@@ -25,7 +28,17 @@ import server.pome.user.service.UserService;
 @RequestMapping("/users")
 @Tag(name = "User", description = "회원 API")
 public class UserController {
+
   private final UserService userService;
+
+  // 조회, 수정 API 테스트용 임시 회원가입 API
+  @Operation(summary = "회원가입")
+  @PostMapping("/signup")
+  public ResponseEntity<BaseResponse<CreateUserResponse>> createUser(
+      @Valid @RequestBody CreateUserRequest request) {
+    CreateUserResponse response = userService.createUser(request);
+    return ResponseEntity.ok(BaseResponse.success(response));
+  }
 
   // 로그인
   @Operation(summary = "로그인")
@@ -38,7 +51,25 @@ public class UserController {
   }
 
   // 회원 정보 조회
+  @Operation(summary = "회원 정보 조회")
+  @Parameter(name = "userId", description = "회원 ID", required = true)
+  @GetMapping("/mypage/{userId}")
+  public ResponseEntity<BaseResponse<GetUserResponse>> getUserInfo(
+      @PathVariable Long userId
+  ) {
+    GetUserResponse result = userService.getUserInfo(userId);
+    return ResponseEntity.ok(BaseResponse.success(result));
+  }
 
   // 회원 정보 수정
-
+  @Operation(summary = "회원 정보 수정")
+  @Parameter(name = "userId", description = "회원 ID", required = true)
+  @PatchMapping("/mypage/{userId}")
+  public ResponseEntity<BaseResponse<UpdateUserResponse>> updateUserInfo(
+      @PathVariable Long userId,
+      @Valid @RequestBody UpdateUserRequest updateUserRequest
+  ) {
+    UpdateUserResponse result = userService.updateUserInfo(userId, updateUserRequest);
+    return ResponseEntity.ok(BaseResponse.success(result));
+  }
 }

--- a/pome-server/src/main/java/server/pome/user/dto/request/CreateUserRequest.java
+++ b/pome-server/src/main/java/server/pome/user/dto/request/CreateUserRequest.java
@@ -1,0 +1,17 @@
+package server.pome.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CreateUserRequest {
+
+  @Schema(description = "유저 닉네임", example = "윤현서")
+  private String userName;
+
+  @Schema(description = "유저 닉네임", example = "김혜림")
+  private String nickName;
+
+  @Schema(description = "비밀번호", example = "1234")
+  private String password;
+}

--- a/pome-server/src/main/java/server/pome/user/dto/request/UpdateUserRequest.java
+++ b/pome-server/src/main/java/server/pome/user/dto/request/UpdateUserRequest.java
@@ -1,0 +1,19 @@
+package server.pome.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class UpdateUserRequest {
+  @Schema(description = "유저 이름", example = "윤현서")
+  private String userName;
+  @Schema(description = "유저 닉네임", example = "김혜림")
+  private String nickName;
+  @Schema(description = "자기소개", example = "저와 개발자 포트폴리오 쌓으실 분 구해요!")
+  private String introduction;
+  @Schema(description = "희망 직무", example = "프론트엔드 개발자")
+  private String job;
+  @Schema(description = "매칭 활성화 여부", example = "true")
+  private Boolean matching;
+  // TODO: 프로필 사진 추가
+}

--- a/pome-server/src/main/java/server/pome/user/dto/request/UserLoginRequest.java
+++ b/pome-server/src/main/java/server/pome/user/dto/request/UserLoginRequest.java
@@ -1,0 +1,13 @@
+package server.pome.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserLoginRequest (
+
+  @Schema(title = "아이디", example = "test")
+  @NotBlank(message = "아이디를 입력해주세요.")
+  String loginId
+
+){}
+

--- a/pome-server/src/main/java/server/pome/user/dto/response/CreateUserResponse.java
+++ b/pome-server/src/main/java/server/pome/user/dto/response/CreateUserResponse.java
@@ -1,0 +1,21 @@
+package server.pome.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CreateUserResponse {
+
+  @Schema(description = "회원 ID", example = "1")
+  private Long userId;
+
+  @Schema(description = "유저 닉네임", example = "윤현서")
+  private String userName;
+
+  @Schema(description = "유저 닉네임", example = "김혜림")
+  private String nickName;
+}

--- a/pome-server/src/main/java/server/pome/user/dto/response/GetUserResponse.java
+++ b/pome-server/src/main/java/server/pome/user/dto/response/GetUserResponse.java
@@ -1,0 +1,51 @@
+package server.pome.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.pome.global.domain.User;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class GetUserResponse {
+
+  @Schema(description = "회원 ID", example = "1", requiredMode = RequiredMode.REQUIRED)
+  private Long userId;
+  @Schema(description = "이름", example = "윤현서", requiredMode = RequiredMode.REQUIRED)
+  private String userName;
+  @Schema(description = "닉네임", example = "김혜림", requiredMode = RequiredMode.REQUIRED)
+  private String nickName;
+  @Schema(description = "좋아요 수", example = "57", requiredMode = RequiredMode.REQUIRED)
+  private int likeCount;
+  @Schema(description = "포트폴리오 태그 목록", example = "[\"대학재학생\", \"IT\", \"개발자\"]", requiredMode = RequiredMode.NOT_REQUIRED)
+  private List<String> tags;
+  @Schema(description = "매칭 활성화 여부", example = "true", requiredMode = RequiredMode.REQUIRED)
+  private boolean matching;
+  @Schema(description = "자기소개", example = "저와 개발자 포트폴리오 쌓으실 분 구해요!", requiredMode = RequiredMode.NOT_REQUIRED)
+  private String introduction;
+  @Schema(description = "희망 직무", example = "프론트엔드 개발자", requiredMode = RequiredMode.NOT_REQUIRED)
+  private String job;
+
+// TODO: 프로필 이미지 (S3 연동 후 추가)
+
+  public static GetUserResponse from(User user, List<String> tags) {
+
+    return GetUserResponse.builder()
+        .userId(user.getId())
+        .userName(user.getUserName())
+        .nickName(user.getNickName())
+        .likeCount(user.getLikeCount())
+        .tags(tags)
+        .matching(user.getMatching())
+        .introduction(user.getIntroduction())
+        .job(user.getJob())
+        .build();
+  }
+}

--- a/pome-server/src/main/java/server/pome/user/dto/response/UpdateUserResponse.java
+++ b/pome-server/src/main/java/server/pome/user/dto/response/UpdateUserResponse.java
@@ -1,0 +1,37 @@
+package server.pome.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import server.pome.global.domain.User;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UpdateUserResponse {
+  @Schema(description = "유저 ID", example = "1")
+  private Long userId;
+  @Schema(description = "유저 이름", example = "윤현서")
+  private String userName;
+  @Schema(description = "유저 닉네임", example = "김혜림")
+  private String nickName;
+  @Schema(description = "매칭 활성화 여부", example = "true")
+  private Boolean matching;
+  @Schema(description = "자기소개", example = "저와 개발자 포트폴리오 쌓으실 분 구해요!")
+  private String introduction;
+  @Schema(description = "희망 직무", example = "프론트엔드 개발자")
+  private String job;
+  // TODO: 프로필 사진 추가
+
+  public static UpdateUserResponse from(User user) {
+    return UpdateUserResponse.builder()
+        .userId(user.getId())
+        .userName(user.getUserName())
+        .nickName(user.getNickName())
+        .matching(user.getMatching())
+        .introduction(user.getIntroduction())
+        .job(user.getJob())
+        .build();
+  }
+}

--- a/pome-server/src/main/java/server/pome/user/dto/response/UserLoginResponse.java
+++ b/pome-server/src/main/java/server/pome/user/dto/response/UserLoginResponse.java
@@ -1,0 +1,5 @@
+package server.pome.user.dto.response;
+
+public class UserLoginResponse {
+
+}

--- a/pome-server/src/main/java/server/pome/user/repository/UserRepository.java
+++ b/pome-server/src/main/java/server/pome/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package server.pome.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import server.pome.global.domain.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  boolean existsByNickName(String nickName);
+}

--- a/pome-server/src/main/java/server/pome/user/service/UserService.java
+++ b/pome-server/src/main/java/server/pome/user/service/UserService.java
@@ -1,0 +1,11 @@
+package server.pome.user.service;
+
+import server.pome.user.dto.request.UserLoginRequest;
+import server.pome.user.dto.response.UserLoginResponse;
+
+public class UserService {
+
+  public UserLoginResponse login(UserLoginRequest request) {
+    return null;
+  }
+}

--- a/pome-server/src/main/java/server/pome/user/service/UserService.java
+++ b/pome-server/src/main/java/server/pome/user/service/UserService.java
@@ -1,11 +1,92 @@
 package server.pome.user.service;
 
-import server.pome.user.dto.request.UserLoginRequest;
-import server.pome.user.dto.response.UserLoginResponse;
+import static server.pome.global.exception.BaseResponseStatus.*;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.pome.Portfolio.repository.PortfolioRepository;
+import server.pome.global.domain.Portfolio;
+import server.pome.global.domain.User;
+import server.pome.global.exception.BaseException;
+import server.pome.user.dto.request.CreateUserRequest;
+import server.pome.user.dto.request.UpdateUserRequest;
+import server.pome.user.dto.request.UserLoginRequest;
+import server.pome.user.dto.response.CreateUserResponse;
+import server.pome.user.dto.response.GetUserResponse;
+import server.pome.user.dto.response.UpdateUserResponse;
+import server.pome.user.dto.response.UserLoginResponse;
+import server.pome.user.repository.UserRepository;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
 public class UserService {
 
+  private final UserRepository userRepository;
+  private final PortfolioRepository portfolioRepository;
+
+  // 회원가입 (API 테스트용 임시 코드)
+  public CreateUserResponse createUser(CreateUserRequest request) {
+    // 중복 닉네임 방지
+    if (userRepository.existsByNickName(request.getNickName())) {
+      throw new BaseException(DUPLICATE_USER);
+    }
+    User user = new User(
+        null,
+        request.getPassword(),
+        new ArrayList<>(), // fromIds
+        request.getUserName(),
+        request.getNickName(),
+        0, // likeCount
+        true, //matching
+        null, // introduction
+        null, // job
+        null // profileImage
+    );
+
+    userRepository.save(user);
+
+    return CreateUserResponse.builder()
+        .userId(user.getId())
+        .userName(user.getUserName())
+        .nickName(user.getNickName())
+        .build();
+  }
+
+  // 로그인
   public UserLoginResponse login(UserLoginRequest request) {
+    // TODO: 소셜 로그인 구현
     return null;
   }
+
+  // 회원 정보 조회
+  public GetUserResponse getUserInfo(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+    Portfolio portfolio = portfolioRepository.findByUser_Id(userId);
+    List<String> tags = (portfolio != null) ? portfolio.getTag() : new ArrayList<>();
+    return GetUserResponse.from(user, tags);
+  }
+
+  // 회원 정보 수정
+  public UpdateUserResponse updateUserInfo(Long userId, UpdateUserRequest request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+
+    // request에 유효한 값이 있는 경우 저장 (없다면 기존 값 사용)
+    String name = Optional.ofNullable(request.getUserName()).orElse(user.getUserName());
+    String nickname = Optional.ofNullable(request.getNickName()).orElse(user.getNickName());
+    boolean matching = Optional.ofNullable(request.getMatching()).orElse(user.getMatching());
+    String introduction = Optional.ofNullable(request.getIntroduction()).orElse(user.getIntroduction());
+    String job = Optional.ofNullable(request.getJob()).orElse(user.getJob());
+
+    user.updateUserInfo(name, nickname, matching, introduction, job);
+    return UpdateUserResponse.from(user);
+  }
+
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #13 

## 🚀 작업 사항
- 회원 정보 조회 및 수정API 구현
  - 수정 시 null 병합 처리로 유효한 값으로 변경 또는 기존 값 유지
  - 조회 시 portfolio가 없을 경우 tags 빈 배열 반환
- 소셜 로그인 전 테스트용 임시 회원가입 API 추가
  - userName, userNick, password 등록
  - 중복 닉네임 방지 로직 구현
- Portfolio tags 조회용 Repository 추가

## 📢 참고사항
- 메이트 매칭 시 userName을 사용할지, nickName을 사용할지 구체적인 사항을 정해야 함 (정기회의 때 논의 필요)
   - 현재는 nickName을 기준으로 개발하였으므로 userName 으로 변경 시 unique 옵션, 중복 닉네임 방지 로직 수정 필요
   -> nickName은 unique 제약 O, userName은 unique 제약 X 